### PR TITLE
Updating JS so form no longer opens all over the page

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -33,7 +33,10 @@
 		$('html, body').stop().animate({
 			'scrollTop': $( '#generator' ).offset().top
 		}, 900, 'swing', function () {
-			window.location.hash = 'generator'
+			window.location.hash = 'generator';
+			$( '.js #generator' ).attr( {
+				'tabindex': '-1'
+			} ).focus();
 		});
 
 		/**

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,95 +1,8 @@
-
 ( function( $ ) {
-
-	// Let's set up our ARIA for the Generator controls.
-	// We need these only if JavaScript fires.
-	$( '.js .download' ).attr( {
-		'role': 'button',
-		'aria-controls': 'generator',
-		'aria-expanded': 'false'
-	} );
-
-	$( '.js #generator' ).attr( {
-		'aria-expanded': 'false'
-	} );
-
-	// Only show the cancel button if JS is working
-	$( '.js .components-form-cancel' ).css('display','inline-block');
-
-	// Now let's close the form on page load
-	$( document ).ready( function() {
-		$( '#generator' ).slideUp( 0 );
-	} );
-
-	// Define some variables
-	 var form = $( '#generator' ).slideUp( 0 ).clone( true, true ),
-	 	triggerElement;
 
 	// The following happens when a user clicks 'download'
 	$( '.js .download' ).on( 'click', function( e ) {
 		e.preventDefault();
-
-		// Wait, is this section already opened?
-		// If yes, trigger clicking the cancel button and bail
-		if ( 'true' == $( this ).attr( 'aria-expanded') ) {
-			$( ".js .components-form-cancel" ).trigger( "click" );
-			return;
-		}
-		// Otherwise, get down to business.
-
-		// Find out what type we're downloading so's we can count that
-		var type = $( this ).parents( '.theme-type' ).data( 'type' );
-
-		// Also, get the button we clicked
-		triggerElement = $( this );
-
-		// Find out if we're on mobile. If yes, it'll change where we add the form.
-		var mobile = false;
-		if ( $( this ).parents( '.theme-type' ).css( 'float' ) == 'none' ) {
-			mobile = true;
-		}
-
-		// Checking to see where we are on the page, and where the form currently is
-		var thisRow = $( triggerElement ).parents( '.types-row' ),
-		sameRow = $( thisRow ).next( '#generator' ).length;
-
-		// If we're on desktop, and the form is already open, we want to see where it is.
-		// If it's already where we want it, we don't need to re-add it, just change the type that's selected.
-		if ( ! ( false == mobile && 1 == sameRow && 'true' == $( '#generator' ).attr( 'aria-expanded' ) ) ) {
-			// since we've clicked 'download', let's close the generator if it exists
-			$( '#generator' ).slideUp( 500, function() {
-				// ... and get rid of it.
-				$( '#generator' ).remove();
-
-				// Now let's create a nice little function to update our Aria states
-				function updateAria() {
-					$( '.download' ).not( triggerElement ).attr( {
-						'aria-expanded': 'false'
-					} );
-
-					$( triggerElement ).attr( {
-						'aria-expanded': 'true'
-					} );
-
-					$( '.js #generator' ).attr( {
-						'aria-expanded': 'true',
-						'tabindex': '-1'
-					} ).focus();
-				}
-
-				// And re-add the generator to the correct spot, depending whether we're on mobile or not.
-				if( true == mobile ) {
-					// If on mobile, just add that sucka!
-					form.insertAfter( $( triggerElement ).parents( '.theme-type' ) ).slideDown( 500, function() {
-						updateAria();
-					} );
-				} else {
-					form.insertAfter( $( thisRow ) ).slideDown( 500, function() {
-						updateAria();
-					} );
-				}
-			} );
-		}
 
 		// Update the radio buttons to reflect current type
 		if ( $( this ).is( '[data-type="base"]' ) ) {
@@ -116,6 +29,13 @@
 			$( '#type-business' ).attr( 'checked', true );
 		}
 
+		// Scroll to form
+		$('html, body').stop().animate({
+			'scrollTop': $( '#generator' ).offset().top
+		}, 900, 'swing', function () {
+			window.location.hash = 'generator'
+		});
+
 		/**
 		 *Load the g.gif image in order to track downloads
 		 */
@@ -126,73 +46,6 @@
 		// Finally, append the image to our body
 		$( 'body' ).append( '<img src="' + imageURL + '">' );
 		*/
-	} );
-
-
-	// Cancel button.
-	$( document ).on( 'click', '.js .components-form-cancel', function( e ) {
-
-		// Uncheck our theme choice.
-		$( 'input[name="theme-type"]' ).attr( 'checked', false );
-
-		// Change our ARIA states.
-		$( '.js .download' ).attr( {
-			'aria-expanded': 'false'
-		} );
-
-		$( '.js #generator' ).attr( {
-			'aria-expanded': 'false'
-		} );
-
-		$( '.js #generator' ).removeAttr(
-			'tabindex'
-		);
-
-		$( '#generator' ).slideUp( 500, function() {
-			// Return focus to the original 'build' button
-			$( triggerElement ).focus();
-		} );
-	} );
-
-
-	// The form has to be inserted in different spots depending on layout/resolution.
-	// So let's make sure the form closes if the window's resized and passes over that threshold
-	// Otherwise it could end up sitting in a wacky spot
-	var windowWidth = $(window).width();
-	var timeOut;
-	var tabletWidth = 1024;
-
-	function closeIt() {
-		windowWidth = $( window ).width();
-		if ( windowWidth > tabletWidth ) {
-			if ( windowWidth < tabletWidth ) {
-				windowWidth = tabletWidth;
-			}
-		}
-
-		// Close the generator
-		$( '#generator' ).slideUp( 0 );
-
-		// Change our ARIA states
-		$( '.js .download' ).attr( {
-			'aria-expanded': 'false'
-		} );
-
-		$( '.js #generator' ).attr( {
-			'aria-expanded': 'false'
-		} );
-
-		$( '.js #generator' ).removeAttr(
-			'tabindex'
-		);
-	}
-
-	$( window ).resize( function() {
-		var resWidth = $( window ).width();
-		clearTimeout( timeOut );
-		if ( ( windowWidth > tabletWidth && resWidth < tabletWidth ) || ( windowWidth < tabletWidth && resWidth > tabletWidth ) ) {
-			timeOut = setTimeout( closeIt, 100 );
-		}
 	} );
 
 } )( jQuery );

--- a/assets/stylesheets/layout/_panel-download-form.scss
+++ b/assets/stylesheets/layout/_panel-download-form.scss
@@ -13,10 +13,10 @@
 	.wrap {
 		max-width: 700px;
 	}
-}
 
-#base #generator {
-	background-color: lighten( $color__navy-light, 2% );
+	h2 {
+		color: $color__teal-light;
+	}
 }
 
 .generator-form {
@@ -162,26 +162,13 @@
 	fill: #23334e;
 }
 
-#base .gear-set0 {
-	fill: lighten( #23334e, 2% );
-}
-
 .gear-set1 {
 	fill: #293b5a;
-}
-
-#base .gear-set1 {
-	fill: lighten( #293b5a, 2% );
 }
 
 .gear-set2 {
 	fill:#202f49;
 }
-
-#base .gear-set2 {
-	fill: lighten( #202f49, 2% );
-}
-
 
 /**
  * Media queries

--- a/style.css
+++ b/style.css
@@ -1813,8 +1813,8 @@ section {
 	max-width: 700px;
 }
 
-#base #generator {
-	background-color: #1f2f49;
+#generator h2 {
+  color: #A0C3C6;
 }
 
 .generator-form {
@@ -1945,24 +1945,12 @@ section {
 	fill: #23334e;
 }
 
-#base .gear-set0 {
-	fill: #263855;
-}
-
 .gear-set1 {
 	fill: #293b5a;
 }
 
-#base .gear-set1 {
-	fill: #2c4061;
-}
-
 .gear-set2 {
 	fill: #202f49;
-}
-
-#base .gear-set2 {
-	fill: #233450;
 }
 
 /**


### PR DESCRIPTION
Update for #72.

I agree that the form opening all over feels a bit... wiggy? This update removes that functionality from the JS so clicking the 'Build' button will just bring you down to the form under the types instead. 

The radio buttons still update to reflect the type you clicked.
