### PR TITLE
Remove PHP warnings caused by `mkdir()` calls on existing directories

### DIFF
--- a/inc/components-generator.php
+++ b/inc/components-generator.php
@@ -173,11 +173,13 @@ class Components_Generator_Plugin {
 		} else {
 			$this->components_generator_download_file( esc_url_raw( self::$file_data['remote']['download_url'] . $branch ), $repo_file_name );
 		}
-		if ( ! file_exists( 'downloads' ) && ! is_dir( 'downloads' ) ) {
-			mkdir( self::$file_data['server']['root'] . '/downloads/',  0755 );
+		$downloads_dir = self::$file_data['server']['root'] . '/downloads/';
+		if ( ! file_exists( $downloads_dir ) && ! is_dir( $downloads_dir ) ) {
+			mkdir( $downloads_dir,  0755 );
 		}
-		if ( ! file_exists( 'prototype' ) && ! is_dir( 'prototype' ) ) {
-			mkdir( self::$file_data['server']['root'] . '/prototype/',  0755 );
+		$prototype_dir = self::$file_data['server']['root'] . '/prototype/';
+		if ( ! file_exists( $prototype_dir ) && ! is_dir( $prototype_dir ) ) {
+			mkdir( $prototype_dir,  0755 );
 		}
 		// Copy the file to its new directory.
 		if ( $branch_slash == true ) {


### PR DESCRIPTION
Fixes two PHP warnings when loading the site:

![Screenshot](https://cldup.com/c6p6hzwqwU-3000x3000.png)

The warnings are caused because the code checks for a directory, but then attemps to create the directory on another location (which already exists). This is because the working directory doesn't match the target directory where the directory should be created.

Instead of using the actual name of the target directory to be created, its full path is used both to check if it exists, and also to create it if doesn't.
