### PR TITLE
Refactor to fix code generation and optimize ZIP downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 style.css.map
 .sass-cache/*
 assets/.sass-cache/*
+downloads/
+prototype/

--- a/inc/components-generator.php
+++ b/inc/components-generator.php
@@ -23,15 +23,15 @@ class Components_Generator_Plugin {
 		// Server info
 		self::$file_data = array(
 			'server' => array (
-				'root'	=> $_SERVER[ 'DOCUMENT_ROOT' ] . '/',
-				'download_dir' => $_SERVER[ 'DOCUMENT_ROOT' ] . '/downloads/',
-				'prototype_dir' => $_SERVER[ 'DOCUMENT_ROOT' ] . '/prototype/',
+				'root'	=> ABSPATH,
+				'download_dir' => get_stylesheet_directory() . '/downloads/',
+				'prototype_dir' => get_stylesheet_directory() . '/prototype/',
 			),
 
 			// Github repository info
 			'remote' => array (
-				'repo'	=> 'theme-pattern-library',
-				'download_url' => 'https://codeload.github.com/Automattic/theme-pattern-library/zip/',
+				'repo'	=> 'theme-components',
+				'download_url' => 'https://codeload.github.com/Automattic/theme-components/zip/',
 			),
 		);
 
@@ -173,11 +173,13 @@ class Components_Generator_Plugin {
 		} else {
 			$this->components_generator_download_file( esc_url_raw( self::$file_data['remote']['download_url'] . $branch ), $repo_file_name );
 		}
-		if ( ! file_exists( 'downloads' ) && ! is_dir( 'downloads' ) ) {
-			mkdir( self::$file_data['server']['root'] . '/downloads/',  0755 );
+		$downloads_dir = self::$file_data['server']['download_dir'];
+		if ( ! file_exists( $downloads_dir ) && ! is_dir( $downloads_dir ) ) {
+			mkdir( $downloads_dir,  0755 );
 		}
-		if ( ! file_exists( 'prototype' ) && ! is_dir( 'prototype' ) ) {
-			mkdir( self::$file_data['server']['root'] . '/prototype/',  0755 );
+		$prototype_dir = self::$file_data['server']['prototype_dir'];
+		if ( ! file_exists( $prototype_dir ) && ! is_dir( $prototype_dir ) ) {
+			mkdir( $prototype_dir,  0755 );
 		}
 		// Copy the file to its new directory.
 		if ( $branch_slash == true ) {


### PR DESCRIPTION
The ZIP files were downloaded to the Server's Root, which is not an ideal place for temporary downloads. Instead of the Server Root, the WordPress root (`ABSPATH`) is used instead, to avoid possible conflicts.

The `download/` and `prototype/` working directories have been moved inside of the theme's directory, since it makes more sense for those to be placed in such location (instead of residing in the web server's root). Additionally, the `.gitignore` file has been updated to properly ignore transient files in these directories.

Due to the recent renaming of the `theme-pattern-library` repository to the new `theme-components`, the generator code was no longer working, since it was looking for the old repository, which is no longer available.

It was necessary to update the references of the old repository and replace them with the new one in order for the generator to work properly.
