### PR TITLE
Add `README.md` to list of excluded files

### DIFF
--- a/inc/components-generator.php
+++ b/inc/components-generator.php
@@ -366,7 +366,7 @@ class Components_Generator_Plugin {
 		$zip = new ZipArchive;
 		$zip_filename = sprintf( self::$file_data['server']['download_dir'] . '-' . str_replace( '/', '-', $this->type_branch ) . '-%s.zip', md5( print_r( $this->theme, true ) ) );
 		$res = $zip->open( $zip_filename, ZipArchive::CREATE && ZipArchive::OVERWRITE );
-		$exclude_files = array( '.travis.yml', 'codesniffer.ruleset.xml', 'CONTRIBUTING.md', '.git', '.svn', '.DS_Store', '.gitignore', '.', '..' );
+		$exclude_files = array( '.travis.yml', 'codesniffer.ruleset.xml', 'README.md', 'CONTRIBUTING.md', '.git', '.svn', '.DS_Store', '.gitignore', '.', '..' );
 		$exclude_directories = array( '.git', '.svn', '.', '..' );
 
 		$iterator = new RecursiveDirectoryIterator( $this->prototype_dir );


### PR DESCRIPTION
- This way, the file won't be included in generated builds.
- We still want to have this, because we'll likely expand it in the future when we move away from branches.

Fixes #62
