### PR TITLE
Make copy tweaks for launch

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -60,7 +60,7 @@ get_header(); ?>
 					</div>
 					<div class="theme-text">
 						<h2 class="theme-type-title">Just the basics, please</h2>
-						<p>Can&rsquo;t decide? Want to concoct your own starter theme? Don&rsquo;t need any bells or whistles? Our base package is for you.</p>
+						<p>Want to concoct your own starter theme? Don&rsquo;t need any bells or whistles? Our base package is for you.</p>
 						<a href="#generator" class="download button" data-type="base">Build Theme!</a>
 					</div>
 				</div><!-- .theme-type -->
@@ -128,7 +128,7 @@ get_header(); ?>
 
 					<div class="col">
 						<h2>Want to contribute?</h2>
-						<p>Components is a new project, and we&rsquo;re looking for your input! Have a pattern to share? Want to add a new feature? Found a bug in the code? Head over to the <a href="https://github.com/Automattic/theme-pattern-library">GitHub repo</a>, check out the <a href="https://github.com/Automattic/theme-pattern-library/blob/master/CONTRIBUTING.md">contributor guidelines</a>, and get involved!</p>
+						<p>Components is a new project, and we&rsquo;re looking for your input! Have a pattern to share? Want to add a new feature? Found a bug in the code? Head over to the <a href="https://github.com/Automattic/theme-components">GitHub repo</a>, check out the <a href="https://github.com/Automattic/theme-components/blob/master/CONTRIBUTING.md">contributor guidelines</a>, and get involved!</p>
 
 					</div>
 				</div><!-- .wrap -->

--- a/inc/components-generator.php
+++ b/inc/components-generator.php
@@ -213,7 +213,7 @@ class Components_Generator_Plugin {
 						<div class="theme-input clear">
 							<div class="generator-form-primary">
 								<fieldset>
-									<legend class="components-label">Theme type<span class="required">*<span class="screen-reader-text">Required</span></span></legend>
+									<legend class="components-label">Theme type<span class="required"><span class="screen-reader-text">Required</span></span></legend>
 									<div class="components-radio-block">
 										<?php
 											$i = 0;
@@ -237,7 +237,7 @@ class Components_Generator_Plugin {
 
 							<div class="generator-form-secondary">
 								<div class="components-form-field">
-									<label class="components-label" for="components-name">Theme Name<span class="required">*<span class="screen-reader-text">Required</span></span></label>
+									<label class="components-label" for="components-name">Theme Name<span class="required"><span class="screen-reader-text">Required</span></span></label>
 									<input type="text" id="components-name" class="components-input" name="components_name" placeholder="Awesome Theme" required="" aria-required="true">
 								</div>
 


### PR DESCRIPTION
- Remove "Can't decide" phrase from Base theme copy.
- Remove "required" asterisks from form since we don't explain what they mean. We indicate required fields in other ways and should revisit later.
- Update old links to repo.

Fixes #76
