### PR TITLE
fix(frontpage): Build theme button for classic blog theme type

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -14,7 +14,7 @@
 		}
 
 		if ( $( this ).is( '[data-type="blog-classic"]' ) ) {
-			$( '#type-classic' ).attr( 'checked', true );
+			$( '#type-blog-classic' ).attr( 'checked', true );
 		}
 
 		if ( $( this ).is( '[data-type="magazine"]' ) ) {

--- a/inc/components-generator.php
+++ b/inc/components-generator.php
@@ -61,7 +61,7 @@ class Components_Generator_Plugin {
 
  			'classic' => array (
  				'title'	=> esc_html__( 'Classic Blog', 'components' ),
- 				'id' => esc_attr( 'type-classic' ),
+ 				'id' => esc_attr( 'type-blog-classic' ),
  				'zip_file' => self::$file_data['remote']['repo'] . '-types-blog-classic.zip',
  				'branch' => 'types/blog-classic',
  				'branch_slash' => true,


### PR DESCRIPTION
When user click on build theme button for classic blog theme type, it will auto select classis blog in 'Build your own Components theme' form.
