### PR TITLE
Copy relevant fixes from checkboxes-redesign branch

### DIFF
--- a/assets/stylesheets/layout/_panel-download-form.scss
+++ b/assets/stylesheets/layout/_panel-download-form.scss
@@ -173,16 +173,10 @@
 /**
  * Media queries
  */
-// Stack form on mobile and make sure there's a margin between the two elements
 @include mobile {
-	.generator-form-primary,
-	.generator-form-secondary {
-		margin-bottom: $size__gutter/2;
-		width: 100%;
-	}
-
-	.generator-form-submit {
-		text-align: center;
+	// Hide the form on mobile
+	#generator {
+		display: none;
 	}
 }
 

--- a/assets/stylesheets/layout/_panel-top-robot.scss
+++ b/assets/stylesheets/layout/_panel-top-robot.scss
@@ -5,10 +5,10 @@
 	left: 5%;
 	-ms-transform: translate( 0, -193px ) rotate(195deg); /* make sure robot is visible in IE9, since keyframes are not supported */
 	transform: translate( 0, -400px ) rotate(195deg);
-	-webkit-animation: .2s 1.5s 1 forwards TopRobotDrop;
-	-moz-animation: .2s 1.5s 1 forwards TopRobotDrop;
-	-o-animation: .2s 1.5s 1 forwards TopRobotDrop;
-	animation: .2s 1.5s 1 forwards TopRobotDrop;
+	-webkit-animation: .2s 1s 1 forwards TopRobotDrop;
+	-moz-animation: .2s 1s 1 forwards TopRobotDrop;
+	-o-animation: .2s 1s 1 forwards TopRobotDrop;
+	animation: .2s 1s 1 forwards TopRobotDrop;
 	width: 230px;
 	height: 350px;
 	z-index: 10;

--- a/assets/stylesheets/layout/_panel-types.scss
+++ b/assets/stylesheets/layout/_panel-types.scss
@@ -321,4 +321,17 @@
 			}
 		}
 	}
+
+	#types {
+		.theme-type {
+			padding-bottom: 2em;
+		}
+		.types-row:last-of-type {
+			padding-bottom: 0;
+		}
+	}
+
+	.download.button {
+		display: none;
+	}
 }

--- a/components/theme-types.php
+++ b/components/theme-types.php
@@ -25,12 +25,12 @@ $types = array(
   'portfolio' => array (
     'title'    => esc_html__( 'Portfolio', 'components' ),
     'filename' => 'portfolio',
-    'text'     => esc_html__( 'If you&rsquo;re the creative type, this is the theme package for you. Image-focused, the portfolio layout uses a portfolio custom post type to easily keep your portfolio items separate from regular posts. It features a gridded portfolio layout, a simple one-column blog template, and a large featured image header.', 'components' ),
+    'text'     => esc_html__( 'Shine a spotlight on creative work with this image-focused starter theme. A gridded layout keeps portfolio items separate from regular posts via a custom post type, while the blog template features a simple one-column look and a large featured-image header.', 'components' ),
   ),
 
   'business' => array (
     'title'    => esc_html__( 'Business', 'components' ),
     'filename' => 'business',
-    'text'     => esc_html__( 'You&rsquo;ve got a million things to worry about; don&rsquo;t let your theme be another. A business starter theme comes with a front page template featuring a custom header, prominent testimonials, and a custom content area. Testimonials can be displayed throughout the theme to add authenticity to your business.', 'components' ),
+    'text'     => esc_html__( 'This starter theme gets right down to business with its front-page template featuring a custom header, prominent testimonials, and a custom content area. Testimonials can be displayed throughout the theme to lend extra credibility and instill customer confidence.', 'components' ),
   ),
 );

--- a/header.php
+++ b/header.php
@@ -63,8 +63,7 @@
 							<?php endif; ?>
 						</div><!-- .site-branding -->
 						<div id="intro">
-							<p>Components is a library of <strong>shareable, reusable patterns</strong> for WordPress themes. Instead of starting from scratch, mix and match from a collection of pre-made components to build your own <strong>custom starter theme</strong>.</p>
-							<p>If you&rsquo;re just starting out, it&rsquo;ll get you <strong>booted up</strong> without needing to reinvent the wheel or write a lot of custom code. If you&rsquo;re an experienced theme developer, you&rsquo;ll find <strong>well-organized, easy-to use code</strong> that you can remix to your heart&rsquo;s delight!</p>
+							<p>The choice is yours: jump-start a blog, portfolio, business, or magazine site – or concoct something completely custom. No matter which route you take, you&rsquo;ll save tons of time and <strong>turbo-charge</strong> your theme&rsquo;s development.
 						</div><!-- #intro -->
 					</div><!-- .intro-content -->
 				</div><!-- .content-wrapper -->

--- a/style.css
+++ b/style.css
@@ -909,85 +909,67 @@ section {
     margin-top: 180px;
     margin-left: 50px; } }
 @media (min-width: 768px) {
-	#masthead .wrap {
-		padding-top: 0;
-		position: relative;
-	}
+  #masthead .wrap {
+    padding-top: 0;
+    position: relative; }
 
-	.chute-wrapper {
-		float: left;
-		margin: 40px 0 -60px 70px;
-		position: relative;
-		z-index: 1;
-	}
+  .chute-wrapper {
+    float: left;
+    margin: 40px 0 -60px 70px;
+    position: relative;
+    z-index: 1; }
 
-	#pipe-chute {
-		position: absolute;
-		top: 0;
-		left: 0;
-	}
+  #pipe-chute {
+    position: absolute;
+    top: 0;
+    left: 0; }
 
-	#pipe-tap {
-		-webkit-animation-name: spin;
-		animation-name: spin;
-		-webkit-animation-duration: 3s;
-		animation-duration: 3s;
-		-webkit-animation-direction: alternate;
-		animation-direction: alternate;
-		-webkit-animation-delay: 5s;
-		animation-delay: 5s;
-		-webkit-animation-fill-mode: forwards;
-		animation-fill-mode: forwards;
-		-webkit-animation-timing-function: cubic-bezier(0.96, -0.08, 0.49, 1.58);
-		animation-timing-function: cubic-bezier(0.96, -0.08, 0.49, 1.58);
-		-webkit-animation-play-state: running;
-		animation-play-state: running;
-		-webkit-animation-iteration-count: infinite;
-		animation-iteration-count: infinite;
-		position: absolute;
-		top: 245px;
-		left: 34px;
-		width: 80px;
-		height: 80px;
-	}
+  #pipe-tap {
+    animation-name: spin;
+    animation-duration: 3s;
+    animation-direction: alternate;
+    animation-delay: 5s;
+    animation-fill-mode: forwards;
+    animation-timing-function: cubic-bezier(0.96, -0.08, 0.49, 1.58);
+    animation-play-state: running;
+    animation-iteration-count: infinite;
+    position: absolute;
+    top: 245px;
+    left: 34px;
+    width: 80px;
+    height: 80px; }
 
-	#pipe-left {
-		margin-left: -40px;
-		margin-top: 36px;
-	}
+  #pipe-left {
+    margin-left: -40px;
+    margin-top: 36px; }
 
-	#stretchy-pipe {
-		position: absolute;
-		left: 175px;
-		right: 98px;
-		background: #A0C3C6;
-		height: 30px;
-		top: 40px;
-	}
+  #stretchy-pipe {
+    position: absolute;
+    left: 175px;
+    right: 98px;
+    background: #A0C3C6;
+    height: 30px;
+    top: 40px; }
 
-	#pipe-rightcrook {
-		float: right;
-		position: absolute;
-		top: 0;
-		right: 20px;
-		margin-top: -14px;
-		vertical-align: top;
-		margin-left: -5px;
-	}
+  #pipe-rightcrook {
+    float: right;
+    position: absolute;
+    top: 0;
+    right: 20px;
+    margin-top: -14px;
+    vertical-align: top;
+    margin-left: -5px; }
 
   /* Move content block to right */
-	#masthead .content-wrapper {
-		float: left;
-		position: relative;
-		width: calc(100% - 300px);
-		z-index: 1;
-	}
+  #masthead .content-wrapper {
+    float: left;
+    position: relative;
+    width: calc(100% - 300px);
+    z-index: 1; }
 
-	#masthead .intro-content {
-		margin: 40px auto 0;
-		max-width: 650px;
-	}
-}
+  #masthead .intro-content {
+    margin: 40px auto 0;
+    max-width: 650px; } }
 /* Rotation animation */
 @keyframes spin {
   0%, 40% {
@@ -1350,7 +1332,15 @@ section {
         left: 0;
         margin: 0;
         max-height: 100%;
-        width: 150px; } }
+        width: 150px; }
+
+  #types .theme-type {
+    padding-bottom: 2em; }
+  #types .types-row:last-of-type {
+    padding-bottom: 0; }
+
+  .download.button {
+    display: none; } }
 #download-base {
   background-color: #A0C3C6; }
   #download-base ::after {
@@ -1426,25 +1416,18 @@ section {
   #extra-info .col:nth-of-type(even) {
     float: right; } }
 #generator {
-	background-color: #1c2a42;
-	color: #f3f2ed;
-	max-height: 100%;
-	overflow: hidden;
-	position: relative;
-	text-align: center;
-}
-
-#generator[tabindex="-1"]:focus {
-	outline: 0;
-}
-
-#generator .wrap {
-	max-width: 700px;
-}
-
-#generator h2 {
-	color: #A0C3C6;
-}
+  background-color: #1c2a42;
+  color: #f3f2ed;
+  max-height: 100%;
+  overflow: hidden;
+  position: relative;
+  text-align: center; }
+  #generator[tabindex="-1"]:focus {
+    outline: 0; }
+  #generator .wrap {
+    max-width: 700px; }
+  #generator h2 {
+    color: #A0C3C6; }
 
 .generator-form {
   padding-bottom: 1.5em;
@@ -1557,13 +1540,8 @@ section {
  * Media queries
  */
 @media (max-width: 767px) {
-  .generator-form-primary,
-  .generator-form-secondary {
-    margin-bottom: 20px;
-    width: 100%; }
-
-  .generator-form-submit {
-    text-align: center; } }
+  #generator {
+    display: none; } }
 @media (min-width: 768px) {
   .generator-form-primary {
     display: inline-block;

--- a/style.css
+++ b/style.css
@@ -998,10 +998,10 @@ section {
   -ms-transform: translate(0, -193px) rotate(195deg);
   /* make sure robot is visible in IE9, since keyframes are not supported */
   transform: translate(0, -400px) rotate(195deg);
-  -webkit-animation: .2s 1.5s 1 forwards TopRobotDrop;
-  -moz-animation: .2s 1.5s 1 forwards TopRobotDrop;
-  -o-animation: .2s 1.5s 1 forwards TopRobotDrop;
-  animation: .2s 1.5s 1 forwards TopRobotDrop;
+  -webkit-animation: .2s 1s 1 forwards TopRobotDrop;
+  -moz-animation: .2s 1s 1 forwards TopRobotDrop;
+  -o-animation: .2s 1s 1 forwards TopRobotDrop;
+  animation: .2s 1s 1 forwards TopRobotDrop;
   width: 230px;
   height: 350px;
   z-index: 10; }


### PR DESCRIPTION
Moving some fixes we made in the checkboxes-redesign branch to the main site, since it may be a bit before that branch can be merged.

Specifically:
- Hiding download buttons/form on mobile (#14)
- Top robot entrance is a bit quicker (#21)
- Updating business and portfolio copy (#104)
- Updating intro copy (#56)

Please note: When this PR is merged, the tagline on the live site should be updated to read:

> Build a solid foundation for your WordPress project with the Components starter-theme generator.
