### PR TITLE
Link to type sections in content.

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -28,16 +28,20 @@
 		if ( $( this ).is( '[data-type="business"]' ) ) {
 			$( '#type-business' ).attr( 'checked', true );
 		}
-
-		// Scroll to form
-		$('html, body').stop().animate({
-			'scrollTop': $( '#generator' ).offset().top
-		}, 900, 'swing', function () {
-			window.location.hash = 'generator';
-			$( '.js #generator' ).attr( {
-				'tabindex': '-1'
-			} ).focus();
-		});
 	} );
 
+	// Smooth scrolling for anchor links.
+	$( 'a[href^="#"]' ).on( 'click', function ( e ) {
+		e.preventDefault();
+		var target = this.hash;
+		var $target = $( target );
+
+		$( 'html, body' ).stop().animate({
+			'scrollTop': $target.offset().top
+		}, 900, 'swing', function () {
+			window.location.hash = target;
+			$( $target ).focus();
+		} );
+		return false;
+	} );
 } )( jQuery );

--- a/assets/stylesheets/shared/_accessibility.scss
+++ b/assets/stylesheets/shared/_accessibility.scss
@@ -27,3 +27,9 @@
 		z-index: 100000; /* Above WP toolbar. */
 	}
 }
+
+/* Do not show the outline on the skip link targets. */
+div[tabindex="-1"]:focus,
+span[tabindex="-1"]:focus {
+	outline: 0;
+}

--- a/front-page.php
+++ b/front-page.php
@@ -49,7 +49,7 @@ get_header(); ?>
 							echo '<div class="wrap types-row">';
 						}
 						?>
-						<div class="theme-type" data-type="<?php echo esc_attr( $type['filename'] ); ?>">
+						<div id="<?php echo esc_attr( $type['filename'] ); ?>" class="theme-type" data-type="<?php echo esc_attr( $type['filename'] ); ?>">
 							<h2 class="theme-type-title"><?php echo $type['title']; ?></h2>
 							<div class="theme-image">
 								<div class="standard-robot">

--- a/header.php
+++ b/header.php
@@ -63,7 +63,7 @@
 							<?php endif; ?>
 						</div><!-- .site-branding -->
 						<div id="intro">
-							<p>The choice is yours: jump-start a blog, portfolio, business, or magazine site – or concoct something completely custom. No matter which route you take, you&rsquo;ll save tons of time and turbo-charge your theme&rsquo;s development.
+							<p>The choice is yours: jump-start a <a href="#blog-classic">blog</a>, <a href="#portfolio">portfolio</a>, <a href="#business">business</a>, or <a href="#magazine">magazine site</a> – or concoct something completely custom. No matter which route you take, you&rsquo;ll save tons of time and turbo-charge your theme&rsquo;s development.
 						</div><!-- #intro -->
 					</div><!-- .intro-content -->
 				</div><!-- .content-wrapper -->

--- a/style.css
+++ b/style.css
@@ -754,6 +754,11 @@ a:hover, a:active {
     width: auto;
     z-index: 100000;
     /* Above WP toolbar. */ }
+/* Do not show the outline on the skip link targets. */
+div[tabindex="-1"]:focus,
+span[tabindex="-1"]:focus {
+  outline: 0;
+}
 
 /*--------------------------------------------------------------
 # Alignments


### PR DESCRIPTION
- Adds links to type sections in content.
- Make sure `div` and `span` elements with `tabindex="-1"` don't have outline.
- Enable smooth scrolling for all anchor links.

Fixes #123
