### PR TITLE
34 code review changes

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -14,7 +14,7 @@
 	<footer id="colophon" class="site-footer" role="contentinfo">
 
 		<div class="automattic-credit">
-			An <a href="http://automattic.com/" id="automattic-credit-logo">Automattic</a>
+			An <a href="<?php echo esc_url( __( 'https://automattic.com/', 'components' ) ); ?>" id="automattic-credit-logo">Automattic</a>
 			<?php
 			$words = array( 'Production', 'Joint', 'Medley', 'Experiment', 'Ruckus', 'Invention', 'Creation', 'Thingamajig', 'Opus', 'Brainchild', 'Contraption' );
 			echo $words[ mt_rand( 0, count( $words) -1 ) ];
@@ -23,7 +23,7 @@
 
 		<div class="site-info">
 			<?php do_action( 'components_credits' ); ?>
-			<a href="http://wordpress.org/" title="<?php esc_attr_e( 'A Semantic Personal Publishing Platform', 'components' ); ?>" rel="generator"><?php printf( __( 'Proudly powered by %s', 'components' ), 'WordPress' ); ?></a>
+			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'components' ) ); ?>" title="<?php esc_attr_e( 'A Semantic Personal Publishing Platform', 'components' ); ?>" rel="generator"><?php printf( __( 'Proudly powered by %s', 'components' ), 'WordPress' ); ?></a>
 		</div><!-- .site-info -->
 
 	</footer><!-- #colophon -->

--- a/front-page.php
+++ b/front-page.php
@@ -37,43 +37,37 @@ get_header(); ?>
 
 			<section id="types">
 				<?php
-					// Get the theme types
-					$types = components_theme_types();
-					if ( isset( $types ) && is_array( $types ) ) :
-						// Randomise order of types so as not to favour any in particular
-						shuffle( $types );
-						// Prepend the Base type
-						// Iterate through each theme type and output formatted text
-						$i = 0;
-						foreach ( $types as $type ) :
-							if ( 0 == $i % 2 ) {
-								echo $i > 0 ? '</div>' : ''; // close div if it's not the first
-								echo '<div class="wrap types-row">';
-							}
-							?>
-							<div id="<?php echo esc_attr( $type['filename'] ); ?>" class="theme-type" data-type="<?php echo esc_attr( $type['filename'] ); ?>">
-								<h2 class="theme-type-title"><?php echo $type['title']; ?></h2>
-								<div class="theme-image">
-									<div class="standard-robot">
-										<?php echo file_get_contents( get_template_directory() . '/assets/img/layout-' . $type['filename'] . '.svg' ); ?>
+					// Prepend the Base type
+					// Iterate through each theme type and output formatted text
+					$i = 0;
+					foreach ( components_theme_types() as $type ) :
+						if ( 0 == $i % 2 ) {
+							echo $i > 0 ? '</div>' : ''; // close div if it's not the first
+							echo '<div class="wrap types-row">';
+						}
+						?>
+						<div id="<?php echo esc_attr( $type['filename'] ); ?>" class="theme-type" data-type="<?php echo esc_attr( $type['filename'] ); ?>">
+							<h2 class="theme-type-title"><?php echo $type['title']; ?></h2>
+							<div class="theme-image">
+								<div class="standard-robot">
+									<?php echo file_get_contents( get_template_directory() . '/assets/img/layout-' . $type['filename'] . '.svg' ); ?>
 
-										<?php echo file_get_contents( get_template_directory() . '/assets/img/robot-' . $type['filename'] . '.svg' ); ?>
-									</div>
-									<div class="mobile-robot">
-										<?php echo file_get_contents( get_template_directory() . '/assets/img/mobile-robot-' . $type['filename'] . '.svg' ); ?>
-									</div>
+									<?php echo file_get_contents( get_template_directory() . '/assets/img/robot-' . $type['filename'] . '.svg' ); ?>
 								</div>
-								<div class="theme-text">
-									<p><?php echo $type['text']; ?></p>
-									<a href="#generator" class="download button" data-type="<?php echo esc_attr( $type['filename'] ); ?>">Build <span class="screen-reader-text"><?php echo $type['title']; ?></span> Theme!</a>
+								<div class="mobile-robot">
+									<?php echo file_get_contents( get_template_directory() . '/assets/img/mobile-robot-' . $type['filename'] . '.svg' ); ?>
 								</div>
-							</div><!-- .theme-type -->
+							</div>
+							<div class="theme-text">
+								<p><?php echo $type['text']; ?></p>
+								<a href="#generator" class="download button" data-type="<?php echo esc_attr( $type['filename'] ); ?>">Build <span class="screen-reader-text"><?php echo $type['title']; ?></span> Theme!</a>
+							</div>
+						</div><!-- .theme-type -->
 
-							<?php $i++; ?>
-						<?php endforeach; ?>
-						</div> <!-- .types-row -->
+						<?php $i++; ?>
+					<?php endforeach; ?>
+					</div> <!-- .types-row -->
 
-					<?php endif; ?>
 			</section><!-- #types -->
 
 			<?php do_action( 'render_types_form' ); ?>

--- a/front-page.php
+++ b/front-page.php
@@ -29,7 +29,7 @@ get_header(); ?>
 					<div class="theme-text">
 						<h2 class="theme-type-title">Just the basics, please</h2>
 						<p>Want to concoct your own starter theme? Don&rsquo;t need any bells or whistles? Our base package is for you.</p>
-						<a href="#generator" class="download button" data-type="base">Build <span class="screen-reader-text">Base</span> Theme!</a>
+						<a href="<?php echo esc_url( __( '#generator', 'components' ) ); ?>" class="download button" data-type="base">Build <span class="screen-reader-text">Base</span> Theme!</a>
 					</div>
 				</div><!-- .theme-type -->
 
@@ -60,7 +60,7 @@ get_header(); ?>
 							</div>
 							<div class="theme-text">
 								<p><?php echo $type['text']; ?></p>
-								<a href="#generator" class="download button" data-type="<?php echo esc_attr( $type['filename'] ); ?>">Build <span class="screen-reader-text"><?php echo $type['title']; ?></span> Theme!</a>
+								<a href="<?php echo esc_url( __( '#generator', 'components' ) ); ?>" class="download button" data-type="<?php echo esc_attr( $type['filename'] ); ?>">Build <span class="screen-reader-text"><?php echo $type['title']; ?></span> Theme!</a>
 							</div>
 						</div><!-- .theme-type -->
 
@@ -92,7 +92,7 @@ get_header(); ?>
 
 					<div class="col">
 						<h2>Want to contribute?</h2>
-						<p>Components is a new project, and we&rsquo;re looking for your input! Have a pattern to share? Want to add a new feature? Found a bug in the code? Head over to the <a href="https://github.com/Automattic/theme-components">GitHub repo</a>, check out the <a href="https://github.com/Automattic/theme-components/blob/master/CONTRIBUTING.md">contributor guidelines</a>, and get involved!</p>
+						<p>Components is a new project, and we&rsquo;re looking for your input! Have a pattern to share? Want to add a new feature? Found a bug in the code? Head over to the <a href="<?php echo esc_url( __( 'https://github.com/Automattic/theme-components', 'components' ) ); ?>">GitHub repo</a>, check out the <a href="<?php echo esc_url( __( 'https://github.com/Automattic/theme-components/blob/master/CONTRIBUTING.md', 'components' ) ); ?>">contributor guidelines</a>, and get involved!</p>
 
 					</div>
 				</div><!-- .wrap -->

--- a/front-page.php
+++ b/front-page.php
@@ -105,7 +105,7 @@ get_header(); ?>
 						<?php foreach ( components_get_contributors() as $contributor ) : ?>
 							<?php
 								$name = '@' . $contributor->login;
-								$contributions = sprintf( '%d %s', $contributor->contributions, _n( 'contribution', 'contributions', $contributor->contributions ) );
+								$contributions = sprintf( '%d %s', $contributor->contributions, _n( 'contribution', 'contributions', $contributor->contributions, 'components' ) );
 								$url = sprintf( 'http://github.com/%s', $contributor->login );
 								$avatar_url = add_query_arg( 's', 280, $contributor->avatar_url );
 								$avatar_url = add_query_arg( 'd', esc_url_raw( 'https://secure.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=280' ), $avatar_url );

--- a/front-page.php
+++ b/front-page.php
@@ -37,41 +37,43 @@ get_header(); ?>
 
 			<section id="types">
 				<?php
-					require get_template_directory() . '/components/theme-types.php';
-					// Randomise order of types so as not to favour any in particular
-					shuffle( $types );
-					// Prepend the Base type
-					// Iterate through each theme type and output formatted text
-					$i = 0;
-					foreach ( $types as $type ) :
-						if ( 0 == $i % 2 ) {
-							echo $i > 0 ? '</div>' : ''; // close div if it's not the first
-							echo '<div class="wrap types-row">';
-						}
-						?>
-						<div id="<?php echo esc_attr( $type['filename'] ); ?>" class="theme-type" data-type="<?php echo esc_attr( $type['filename'] ); ?>">
-							<h2 class="theme-type-title"><?php echo $type['title']; ?></h2>
-							<div class="theme-image">
-								<div class="standard-robot">
-									<?php echo file_get_contents( get_template_directory() . '/assets/img/layout-' . $type['filename'] . '.svg' ); ?>
+					// Get the theme types
+					$types = components_theme_types();
+					if ( isset( $types ) && is_array( $types ) ) :
+						// Randomise order of types so as not to favour any in particular
+						shuffle( $types );
+						// Prepend the Base type
+						// Iterate through each theme type and output formatted text
+						$i = 0;
+						foreach ( $types as $type ) :
+							if ( 0 == $i % 2 ) {
+								echo $i > 0 ? '</div>' : ''; // close div if it's not the first
+								echo '<div class="wrap types-row">';
+							}
+							?>
+							<div id="<?php echo esc_attr( $type['filename'] ); ?>" class="theme-type" data-type="<?php echo esc_attr( $type['filename'] ); ?>">
+								<h2 class="theme-type-title"><?php echo $type['title']; ?></h2>
+								<div class="theme-image">
+									<div class="standard-robot">
+										<?php echo file_get_contents( get_template_directory() . '/assets/img/layout-' . $type['filename'] . '.svg' ); ?>
 
-									<?php echo file_get_contents( get_template_directory() . '/assets/img/robot-' . $type['filename'] . '.svg' ); ?>
+										<?php echo file_get_contents( get_template_directory() . '/assets/img/robot-' . $type['filename'] . '.svg' ); ?>
+									</div>
+									<div class="mobile-robot">
+										<?php echo file_get_contents( get_template_directory() . '/assets/img/mobile-robot-' . $type['filename'] . '.svg' ); ?>
+									</div>
 								</div>
-								<div class="mobile-robot">
-									<?php echo file_get_contents( get_template_directory() . '/assets/img/mobile-robot-' . $type['filename'] . '.svg' ); ?>
+								<div class="theme-text">
+									<p><?php echo $type['text']; ?></p>
+									<a href="#generator" class="download button" data-type="<?php echo esc_attr( $type['filename'] ); ?>">Build <span class="screen-reader-text"><?php echo $type['title']; ?></span> Theme!</a>
 								</div>
-							</div>
-							<div class="theme-text">
-								<p><?php echo $type['text']; ?></p>
-								<a href="#generator" class="download button" data-type="<?php echo esc_attr( $type['filename'] ); ?>">Build <span class="screen-reader-text"><?php echo $type['title']; ?></span> Theme!</a>
-							</div>
-						</div><!-- .theme-type -->
+							</div><!-- .theme-type -->
 
-						<?php $i++; ?>
-					<?php endforeach; ?>
+							<?php $i++; ?>
+						<?php endforeach; ?>
+						</div> <!-- .types-row -->
 
-					</div> <!-- .types-row -->
-
+					<?php endif; ?>
 			</section><!-- #types -->
 
 			<?php do_action( 'render_types_form' ); ?>

--- a/functions.php
+++ b/functions.php
@@ -122,11 +122,14 @@ function components_get_contributors() {
  * @return $types Array
  */
 function components_theme_types() {
+	// Get the theme types
 	require get_template_directory() . '/components/theme-types.php';
-	if ( isset( $types ) ) {
+	if ( isset( $types ) && is_array( $types ) ) {
+		// Randomise order of types so as not to favour any in particular
+		shuffle( $types );
 		return $types;
 	} else {
-		return false;
+		return array();
 	}
 }
 

--- a/functions.php
+++ b/functions.php
@@ -63,15 +63,13 @@ if ( ! function_exists( 'components_content_width' ) ) {
 	add_action( 'after_setup_theme', 'components_content_width', 0 );
 } // components_content_width
 
-if ( ! function_exists( 'components_typekit' ) ) {
-	/**
-	 * Enqueue TypeKit fonts.
-	 */
-	function components_typekit() {
-		wp_enqueue_script( 'components_typekit', '//use.typekit.net/adl7prd.js' );
-	}
-	add_action( 'wp_enqueue_scripts', 'components_typekit' );
-} // components_typekit
+/**
+ * Enqueue TypeKit fonts.
+ */
+function components_typekit() {
+	wp_enqueue_script( 'components_typekit', '//use.typekit.net/adl7prd.js' );
+}
+add_action( 'wp_enqueue_scripts', 'components_typekit' );
 
 if ( ! function_exists( 'components_typekit_inline' ) ) {
 	/**
@@ -97,20 +95,18 @@ if ( ! function_exists( 'components_javascript_detection' ) ) {
 	add_action( 'wp_head', 'components_javascript_detection', 0 );
 } // components_javascript_detection
 
-if ( ! function_exists( 'components_scripts' ) ) {
-	/**
-	 * Enqueue scripts and styles.
-	 */
-	function components_scripts() {
-		wp_enqueue_style( 'components-style', get_stylesheet_uri() );
+/**
+ * Enqueue scripts and styles.
+ */
+function components_scripts() {
+	wp_enqueue_style( 'components-style', get_stylesheet_uri() );
 
-		wp_enqueue_script( 'components', get_template_directory_uri() . '/assets/js/main.js', array( 'jquery' ), '20120206', true );
+	wp_enqueue_script( 'components', get_template_directory_uri() . '/assets/js/main.js', array( 'jquery' ), '20120206', true );
 
-		wp_enqueue_script( 'components-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix.js', array(), '20130115', true );
+	wp_enqueue_script( 'components-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix.js', array(), '20130115', true );
 
-	}
-	add_action( 'wp_enqueue_scripts', 'components_scripts' );
-} // components_scripts
+}
+add_action( 'wp_enqueue_scripts', 'components_scripts' );
 
 if ( ! function_exists( 'components_get_contributors' ) ) {
 	/**

--- a/functions.php
+++ b/functions.php
@@ -118,6 +118,19 @@ function components_get_contributors() {
 }
 
 /**
+ * components_theme_types Returns an array of types
+ * @return $types Array
+ */
+function components_theme_types() {
+	require get_template_directory() . '/components/theme-types.php';
+	if ( isset( $types ) ) {
+		return $types;
+	} else {
+		return false;
+	}
+}
+
+/**
  * Load Jetpack compatibility file.
  */
 require get_template_directory() . '/inc/jetpack.php';

--- a/functions.php
+++ b/functions.php
@@ -5,133 +5,150 @@
  * @package components
  */
 
-if ( ! function_exists( 'components_setup' ) ) :
-/**
- * Sets up theme defaults and registers support for various WordPress features.
- *
- * Note that this function is hooked into the after_setup_theme hook, which
- * runs before the init hook. The init hook is too late for some features, such
- * as indicating support for post thumbnails.
- */
-function components_setup() {
-	/*
-	 * Make theme available for translation.
-	 * Translations can be filed in the /languages/ directory.
-	 * If you're building a theme based on components, use a find and replace
-	 * to change 'components' to the name of your theme in all the template files
+if ( ! function_exists( 'components_setup' ) ) {
+	/**
+	 * Sets up theme defaults and registers support for various WordPress features.
+	 *
+	 * Note that this function is hooked into the after_setup_theme hook, which
+	 * runs before the init hook. The init hook is too late for some features, such
+	 * as indicating support for post thumbnails.
 	 */
-	load_theme_textdomain( 'components', get_template_directory() . '/languages' );
+	function components_setup() {
+		/*
+		 * Make theme available for translation.
+		 * Translations can be filed in the /languages/ directory.
+		 * If you're building a theme based on components, use a find and replace
+		 * to change 'components' to the name of your theme in all the template files
+		 */
+		load_theme_textdomain( 'components', get_template_directory() . '/languages' );
 
-	// Add default posts and comments RSS feed links to head.
-	add_theme_support( 'automatic-feed-links' );
+		// Add default posts and comments RSS feed links to head.
+		add_theme_support( 'automatic-feed-links' );
 
-	/*
-	 * Let WordPress manage the document title.
-	 * By adding theme support, we declare that this theme does not use a
-	 * hard-coded <title> tag in the document head, and expect WordPress to
-	 * provide it for us.
-	 */
-	add_theme_support( 'title-tag' );
+		/*
+		 * Let WordPress manage the document title.
+		 * By adding theme support, we declare that this theme does not use a
+		 * hard-coded <title> tag in the document head, and expect WordPress to
+		 * provide it for us.
+		 */
+		add_theme_support( 'title-tag' );
 
-	/*
-	 * Switch default core markup for search form, comment form, and comments
-	 * to output valid HTML5.
-	 */
-	add_theme_support( 'html5', array(
-		'search-form',
-		'comment-form',
-		'comment-list',
-		'gallery',
-		'caption',
-	) );
-}
-endif; // components_setup
-add_action( 'after_setup_theme', 'components_setup' );
-
-/**
- * Set the content width in pixels, based on the theme's design and stylesheet.
- *
- * Priority 0 to make it available to lower priority callbacks.
- *
- * @global int $content_width
- */
-function components_content_width() {
-	$GLOBALS['content_width'] = apply_filters( 'components_content_width', 640 );
-}
-add_action( 'after_setup_theme', 'components_content_width', 0 );
-
-/**
- * Enqueue TypeKit fonts.
- */
-function components_typekit() {
-	wp_enqueue_script( 'components_typekit', '//use.typekit.net/adl7prd.js' );
-}
-add_action( 'wp_enqueue_scripts', 'components_typekit' );
-
-// Inject Typekit code into header
-function components_typekit_inline() {
-	if ( wp_script_is( 'components_typekit', 'done' ) ) : ?>
-		<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
-<?php endif;
-}
-add_action( 'wp_head', 'components_typekit_inline' );
-
-/**
- * Handles JavaScript detection.
- *
- * Adds a `js` class to the root `<html>` element when JavaScript is detected.
- */
-function components_javascript_detection() {
-	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
-}
-add_action( 'wp_head', 'components_javascript_detection', 0 );
-
-/**
- * Enqueue scripts and styles.
- */
-function components_scripts() {
-	wp_enqueue_style( 'components-style', get_stylesheet_uri() );
-
-	wp_enqueue_script( 'components', get_template_directory_uri() . '/assets/js/main.js', array( 'jquery' ), '20120206', true );
-
-	wp_enqueue_script( 'components-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix.js', array(), '20130115', true );
-
-}
-add_action( 'wp_enqueue_scripts', 'components_scripts' );
-
-/**
- * Returns an array of contributors from Github.
- */
-function components_get_contributors() {
-	$transient_key = 'components_contributors';
-	$contributors = get_transient( $transient_key );
-	if ( false !== $contributors )
-		return $contributors;
-	$response = wp_remote_get( 'https://api.github.com/repos/Automattic/theme-components/contributors?per_page=100' );
-	if ( is_wp_error( $response ) )
-		return array();
-	$contributors = json_decode( wp_remote_retrieve_body( $response ) );
-	if ( ! is_array( $contributors ) )
-		return array();
-	set_transient( $transient_key, $contributors, HOUR_IN_SECONDS );
-	return (array) $contributors;
-}
-
-/**
- * components_theme_types Returns an array of types
- * @return $types Array
- */
-function components_theme_types() {
-	// Get the theme types
-	require get_template_directory() . '/components/theme-types.php';
-	if ( isset( $types ) && is_array( $types ) ) {
-		// Randomise order of types so as not to favour any in particular
-		shuffle( $types );
-		return $types;
-	} else {
-		return array();
+		/*
+		 * Switch default core markup for search form, comment form, and comments
+		 * to output valid HTML5.
+		 */
+		add_theme_support( 'html5', array(
+			'search-form',
+			'comment-form',
+			'comment-list',
+			'gallery',
+			'caption',
+		) );
 	}
-}
+	add_action( 'after_setup_theme', 'components_setup' );
+} // components_setup
+
+
+if ( ! function_exists( 'components_content_width' ) ) {
+	/**
+	 * Set the content width in pixels, based on the theme's design and stylesheet.
+	 *
+	 * Priority 0 to make it available to lower priority callbacks.
+	 *
+	 * @global int $content_width
+	 */
+	function components_content_width() {
+		$GLOBALS['content_width'] = apply_filters( 'components_content_width', 640 );
+	}
+	add_action( 'after_setup_theme', 'components_content_width', 0 );
+} // components_content_width
+
+if ( ! function_exists( 'components_typekit' ) ) {
+	/**
+	 * Enqueue TypeKit fonts.
+	 */
+	function components_typekit() {
+		wp_enqueue_script( 'components_typekit', '//use.typekit.net/adl7prd.js' );
+	}
+	add_action( 'wp_enqueue_scripts', 'components_typekit' );
+} // components_typekit
+
+if ( ! function_exists( 'components_typekit_inline' ) ) {
+	/**
+	 * Inject Typekit code into header
+	 */
+	function components_typekit_inline() {
+		if ( wp_script_is( 'components_typekit', 'done' ) ) : ?>
+			<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+	<?php endif;
+	}
+	add_action( 'wp_head', 'components_typekit_inline' );
+} // components_typekit_inline
+
+if ( ! function_exists( 'components_javascript_detection' ) ) {
+	/**
+	 * Handles JavaScript detection.
+	 *
+	 * Adds a `js` class to the root `<html>` element when JavaScript is detected.
+	 */
+	function components_javascript_detection() {
+		echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
+	}
+	add_action( 'wp_head', 'components_javascript_detection', 0 );
+} // components_javascript_detection
+
+if ( ! function_exists( 'components_scripts' ) ) {
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	function components_scripts() {
+		wp_enqueue_style( 'components-style', get_stylesheet_uri() );
+
+		wp_enqueue_script( 'components', get_template_directory_uri() . '/assets/js/main.js', array( 'jquery' ), '20120206', true );
+
+		wp_enqueue_script( 'components-skip-link-focus-fix', get_template_directory_uri() . '/assets/js/skip-link-focus-fix.js', array(), '20130115', true );
+
+	}
+	add_action( 'wp_enqueue_scripts', 'components_scripts' );
+} // components_scripts
+
+if ( ! function_exists( 'components_get_contributors' ) ) {
+	/**
+	 * Returns an array of contributors from Github.
+	 */
+	function components_get_contributors() {
+		$transient_key = 'components_contributors';
+		$contributors = get_transient( $transient_key );
+		if ( false !== $contributors )
+			return $contributors;
+		$response = wp_remote_get( 'https://api.github.com/repos/Automattic/theme-components/contributors?per_page=100' );
+		if ( is_wp_error( $response ) )
+			return array();
+		$contributors = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( ! is_array( $contributors ) )
+			return array();
+		set_transient( $transient_key, $contributors, HOUR_IN_SECONDS );
+		return (array) $contributors;
+	}
+} // components_get_contributors
+
+if ( ! function_exists( 'components_theme_types' ) ) {
+	/**
+	 * components_theme_types Returns an array of types
+	 * @return $types Array
+	 */
+	function components_theme_types() {
+		// Get the theme types
+		require get_template_directory() . '/components/theme-types.php';
+		if ( isset( $types ) && is_array( $types ) ) {
+			// Randomise order of types so as not to favour any in particular
+			shuffle( $types );
+			return $types;
+		} else {
+			return array();
+		}
+	}
+} // components_theme_types
 
 /**
  * Load Jetpack compatibility file.

--- a/header.php
+++ b/header.php
@@ -19,7 +19,7 @@
 
 <body <?php body_class(); ?>>
 <div id="page" class="hfeed site">
-	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'components' ); ?></a>
+	<a class="skip-link screen-reader-text" href="<?php echo esc_url( __( '#content', 'components' ) ); ?>"><?php esc_html_e( 'Skip to content', 'components' ); ?></a>
 
 
 	<?php if ( is_front_page() ) { ?>
@@ -63,7 +63,7 @@
 							<?php endif; ?>
 						</div><!-- .site-branding -->
 						<div id="intro">
-							<p>The choice is yours: jump-start a <a href="#blog-classic">blog</a>, <a href="#portfolio">portfolio</a>, <a href="#business">business</a>, or <a href="#magazine">magazine site</a> – or concoct something completely custom. No matter which route you take, you&rsquo;ll save tons of time and turbo-charge your theme&rsquo;s development.
+							<p>The choice is yours: jump-start a <a href="<?php echo esc_url( __( '#blog-classic', 'components' ) ); ?>">blog</a>, <a href="<?php echo esc_url( __( '#portfolio', 'components' ) ); ?>">portfolio</a>, <a href="<?php echo esc_url( __( '#business', 'components' ) ); ?>">business</a>, or <a href="<?php echo esc_url( __( '#magazine', 'components' ) ); ?>">magazine site</a> – or concoct something completely custom. No matter which route you take, you&rsquo;ll save tons of time and turbo-charge your theme&rsquo;s development.
 						</div><!-- #intro -->
 					</div><!-- .intro-content -->
 				</div><!-- .content-wrapper -->

--- a/inc/components-generator.php
+++ b/inc/components-generator.php
@@ -869,10 +869,11 @@ class Components_Generator_Plugin {
 			if ( in_array( basename( $filename ), $exclude_files ) ) {
 				continue;
 			}
-			foreach ( $exclude_directories as $directory )
+			foreach ( $exclude_directories as $directory ) {
 				if ( strstr( $filename, "/{$directory}/" ) ) {
 					continue 2; // continue the parent foreach loop
 				}
+			}
 			$local_filename = str_replace( trailingslashit( $this->prototype_dir ), '', $filename );
 			$contents = file_get_contents( $filename );
 			$contents = apply_filters( 'components_generator_file_contents', $contents, $local_filename );

--- a/inc/components-generator.php
+++ b/inc/components-generator.php
@@ -84,7 +84,7 @@ class Components_Generator_Plugin {
 			// Create a JSON file from our $types array so that we can use it for as a cache for rendering the generator form.
 			file_put_contents( $this->build_dir . '/types.json', json_encode( $types, JSON_PRETTY_PRINT ) );
 		} else {
-			$this->log_message( __( 'Error: type.json was not rebuilt successfully because configs were not able to be read.' ) );
+			$this->log_message( __( 'Error: type.json was not rebuilt successfully because configs were not able to be read.', 'components' ) );
 		}
 
 	}
@@ -1002,7 +1002,7 @@ class Components_Generator_Plugin {
 
 			// Create the directory recursively
 			if ( ! mkdir( $directory, 0755, true ) ) {
-				$this->log_message( sprintf( __( 'Error: %s directory was not able to be created.' ), $directory ) );
+				$this->log_message( sprintf( __( 'Error: %s directory was not able to be created.', 'components' ), $directory ) );
 			}
 
 		} else if ( $delete_if_exists && is_dir( $directory ) ) {
@@ -1016,7 +1016,7 @@ class Components_Generator_Plugin {
 	 */
 	public function delete_file( $URI ) {
 		if ( ! unlink( $URI ) ) {
-			$this->log_message( sprintf( __( 'Error: %s file was not able to be deleted.' ), $URI ) );
+			$this->log_message( sprintf( __( 'Error: %s file was not able to be deleted.', 'components' ), $URI ) );
 		}
 	}
 
@@ -1030,7 +1030,7 @@ class Components_Generator_Plugin {
 		foreach ( $files as $fileinfo ) {
 			$fname = $fileinfo->isDir() ? 'rmdir' : 'unlink';
 			if ( ! call_user_func( $fname, $fileinfo->getRealPath() ) ) {
-				$this->log_message( sprintf( __( 'Error: %1$s function was not able to be executed. Arguments were: %2$s.' ), $fname, $fileinfo->getRealPath() ) );
+				$this->log_message( sprintf( __( 'Error: %1$s function was not able to be executed. Arguments were: %2$s.', 'components' ), $fname, $fileinfo->getRealPath() ) );
 			}
 		}
 		return rmdir( $directory );


### PR DESCRIPTION
Here's a PR with my review changes, I moved theme-types into a function in case we ever want to make it dynamic from a database call (instead of a file) we would just need to remove the file require, and do the db call.

I have a few additional queries though:

**1) front-page.php**
- Why are we using file_get_contents() instead of WP_Filesystem?
- There is 1 instance of a different text domain on line 108, not sure why this is the case:
  $contributions = sprintf( '%d %s', $contributor->contributions, _n( 'contribution', 'contributions', $contributor->contributions ) );

**(2) components-generator.php**
- In _get_types()_ function, why is $types declared as static, when it's immediately changed?

_General_
- There are a number of large functions. Perhaps we should refactor and split up? Or at least add some additional logging inside the larger functions. 
- The syntax is good, but it always depends how pedantic we want to be? :) Checking for every type etc.
- I noticed in some instances, function args have default values, while other don't.

_[Lines 868-880](https://github.com/Automattic/components.underscores.me/blob/34_code_review_changes/inc/components-generator.php#L868-L880)_
- The nested foreach loops here make me a little nervous, as this is just before the zip is delivered. We want to know if things break here so I would definitely add some logging at this point. Especially as we don't know how this loop will handle under scale.

_[Lines 872-875](https://github.com/Automattic/components.underscores.me/blob/34_code_review_changes/inc/components-generator.php#L872-L875)_
- Are there missing braces here, or supposed to be like this?

Otherwise it's looking great! Nice work guys!

Closes #34 
