### PR TITLE
Specify component file in order to replace author in footer correctly.

### DIFF
--- a/inc/components-generator.php
+++ b/inc/components-generator.php
@@ -764,8 +764,8 @@ class Components_Generator_Plugin {
 			$contents = preg_replace( '/\b' . preg_quote( $this->theme['name'] ) . ' is distributed\b/', 'Components is distributed', $contents );
 			return $contents;
 		}
-		// Special treatment for footer.php
-		if ( 'footer.php' == $filename ) {
+		// Special treatment for site-info.php
+		if ( 'site-info.php' == $filename ) {
 			// <?php printf( __( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="http://automattic.com/" rel="designer">Automattic</a>' );
 			$contents = str_replace( 'http://automattic.com/', esc_url( $this->theme['author_uri'] ), $contents );
 			$contents = str_replace( 'Automattic', $this->theme['author'], $contents );


### PR DESCRIPTION
Themes are currently being generated with "Automattic" in the footer regardless of user input. This seems to be because the wrong filename is specified in the generator: it's looking to replace the text in footer.php, but that text has since been moved to components/footer/site-info.php.

I've updated the generator to look for site-info.php instead. This should fix #150.

Note: I wasn't able to test this, unfortunately. I tried running the components.underscores.me repo as a theme on a vv instance and it just outputs various different php errors. 😢 
