### PR TITLE
Allow valid custom slugs

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -96,7 +96,7 @@
 		}
 		// If the theme slug is not empty, make sure it has no special characters.
 		if ( slug || 0 < slug.length ) {
-			if ( /^[a-z_]\w+$/i.test( slug.trim() ) === false ) {
+			if ( /^[a-z0-9-]+$/i.test( slug.trim() ) === false ) {
 				errors += '<li>Theme slug could not be used to generate valid function names. Special characters are not allowed. <a href="#components-types-slug">Please go back and try again</a>.</li>\n';
 				slugInput.attr( 'aria-invalid', 'true' );
 			} else {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -97,7 +97,7 @@
 		// If the theme slug is not empty, make sure it has no special characters.
 		if ( slug || 0 < slug.length ) {
 			if ( /^[^0-9][a-z0-9-]+$/i.test( slug.trim() ) === false ) {
-				errors += '<li>Theme slug could not be used to generate valid function names. Special characters are not allowed. <a href="#components-types-slug">Please go back and try again</a>.</li>\n';
+				errors += '<li>Theme slug could not be used to generate valid function names. The slug must begin with a lowercase letter and contain only lowercase letters, numbers, and hyphens. <a href="#components-types-slug">Please go back and try again</a>.</li>\n';
 				slugInput.attr( 'aria-invalid', 'true' );
 			} else {
 				// Reset aria-invalid attribue from any previous attempts.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -96,7 +96,7 @@
 		}
 		// If the theme slug is not empty, make sure it has no special characters.
 		if ( slug || 0 < slug.length ) {
-			if ( /^[a-z0-9-]+$/i.test( slug.trim() ) === false ) {
+			if ( /^[^0-9][a-z0-9-]+$/i.test( slug.trim() ) === false ) {
 				errors += '<li>Theme slug could not be used to generate valid function names. Special characters are not allowed. <a href="#components-types-slug">Please go back and try again</a>.</li>\n';
 				slugInput.attr( 'aria-invalid', 'true' );
 			} else {


### PR DESCRIPTION
The client-side form validation for the form that creates a custom Components download does not permit slugs with hyphens. The slug field's placeholder is 'awesome-theme' and hyphenated slugs pass the server-side validation and do, in fact, generate valid function names.

By removing the 'Any Word' regex match (\w) and more specifically matching that it does not begin with a number and then that it only contains lowercase letters or numbers and the hyphen the form will allow for proper custom slugs.

The error message is also edited to more clearly explain how to provide a valid slug.